### PR TITLE
Add linux package to defaults

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,8 +7,10 @@ Storage=volatile
 SystemMaxUse=16M
 ";
 
-pub const BASE_PACKAGES: [&str; 6] = [
+pub const BASE_PACKAGES: [&str; 8] = [
     "base",
+    "linux",
+    "linux-firmware",
     "grub",
     "efibootmgr",
     "intel-ucode",


### PR DESCRIPTION
Should fix mkinitcpio issues due to missing "linux" preset now it's no longer included in "base".

Note this issue only affected newer Arch Linux installs (since the change).