### PR TITLE
Add support for installing AUR packages

### DIFF
--- a/presets/aur_example.toml
+++ b/presets/aur_example.toml
@@ -1,0 +1,2 @@
+packages = ["clang"]
+aur_packages = ["bat-cat-git"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,4 @@
+use super::aur::AurHelper;
 use byte_unit::Byte;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -41,6 +42,10 @@ pub struct CreateCommand {
     #[structopt(short = "p", long = "extra-packages", value_name = "package")]
     pub extra_packages: Vec<String>,
 
+    /// Additional packages to install
+    #[structopt(long = "aur-packages", value_name = "aurpackage")]
+    pub aur_packages: Vec<String>,
+
     /// Enter interactive chroot before unmounting the drive
     #[structopt(short = "i", long = "interactive")]
     pub interactive: bool,
@@ -72,6 +77,9 @@ pub struct CreateCommand {
     /// show non-removable devices
     #[structopt(long = "allow-non-removable")]
     pub allow_non_removable: bool,
+
+    #[structopt(long = "aur-helper", possible_values=&["yay"], default_value="yay")]
+    pub aur_helper: AurHelper,
 }
 
 #[derive(StructOpt)]

--- a/src/aur.rs
+++ b/src/aur.rs
@@ -1,0 +1,39 @@
+use crate::error::ErrorKind;
+use std::str::FromStr;
+
+pub struct AurHelper {
+    pub name: String,
+    pub install_command: Vec<String>,
+}
+
+impl FromStr for AurHelper {
+    type Err = ErrorKind;
+    // Remove make dependencies after install? [y/N]
+    // :: Proceed with installation? [Y/n]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "yay" => Ok(AurHelper {
+                name: String::from("yay"),
+                install_command: vec![
+                    String::from("yay"),
+                    String::from("-S"),
+                    String::from("--nocleanmenu"),
+                    String::from("--nodiffmenu"),
+                    String::from("--noeditmenu"),
+                    String::from("--noupgrademenu"),
+                    String::from("--useask"),
+                    String::from("--removemake"),
+                    String::from("--norebuild"),
+                    String::from("--noconfirm"),
+                    String::from("--answeredit"),
+                    String::from("None"),
+                    String::from("--answerclean"),
+                    String::from("None"),
+                    String::from("--mflags"),
+                    String::from("--noconfirm"),
+                ],
+            }),
+            _ => Err(ErrorKind::AurHelper {}),
+        }
+    }
+}

--- a/src/aur.rs
+++ b/src/aur.rs
@@ -8,8 +8,7 @@ pub struct AurHelper {
 
 impl FromStr for AurHelper {
     type Err = ErrorKind;
-    // Remove make dependencies after install? [y/N]
-    // :: Proceed with installation? [Y/n]
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "yay" => Ok(AurHelper {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,3 +17,5 @@ pub const BASE_PACKAGES: [&str; 8] = [
     "networkmanager",
     "broadcom-wl",
 ];
+
+pub const AUR_DEPENDENCIES: [&str; 3] = ["base-devel", "git", "sudo"];

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,6 +86,9 @@ pub enum ErrorKind {
     #[fail(display = "Error executing preset script")]
     PresetScript,
 
+    #[fail(display = "Error parsing AUR helper string")]
+    AurHelper,
+
     #[fail(display = "Error creating the image")]
     Image,
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -13,6 +13,7 @@ struct Preset {
     script: Option<String>,
     environment_variables: Option<Vec<String>>,
     shared_directories: Option<Vec<PathBuf>>,
+    aur_packages: Option<Vec<String>>,
 }
 
 fn visit_dirs(dir: &Path, filevec: &mut Vec<PathBuf>) -> Result<(), io::Error> {
@@ -46,9 +47,14 @@ impl Preset {
         scripts: &mut Vec<Script>,
         environment_variables: &mut HashSet<String>,
         path: &PathBuf,
+        aur_packages: &mut HashSet<String>,
     ) -> Result<(), ErrorKind> {
         if let Some(preset_packages) = &self.packages {
             packages.extend(preset_packages.clone());
+        }
+
+        if let Some(preset_aur_packages) = &self.aur_packages {
+            aur_packages.extend(preset_aur_packages.clone());
         }
 
         if let Some(preset_environment_variables) = &self.environment_variables {
@@ -94,12 +100,14 @@ pub struct Script {
 
 pub struct PresetsCollection {
     pub packages: HashSet<String>,
+    pub aur_packages: HashSet<String>,
     pub scripts: Vec<Script>,
 }
 
 impl PresetsCollection {
     pub fn load(list: &[PathBuf]) -> Result<Self, Error> {
         let mut packages = HashSet::new();
+        let mut aur_packages = HashSet::new();
         let mut scripts: Vec<Script> = Vec::new();
         let mut environment_variables = HashSet::new();
 
@@ -121,6 +129,7 @@ impl PresetsCollection {
                         &mut scripts,
                         &mut environment_variables,
                         &path,
+                        &mut aur_packages,
                     )?;
                 }
             } else {
@@ -129,6 +138,7 @@ impl PresetsCollection {
                     &mut scripts,
                     &mut environment_variables,
                     &preset,
+                    &mut aur_packages,
                 )?;
             }
         }
@@ -141,6 +151,10 @@ impl PresetsCollection {
             return Err(ErrorKind::MissingEnvironmentVariables(missing_envrionments).into());
         }
 
-        Ok(Self { packages, scripts })
+        Ok(Self {
+            packages,
+            scripts,
+            aur_packages,
+        })
     }
 }


### PR DESCRIPTION
Resolves issue #43 

It might be possible to simplify/remove the sed commands for editing the sudoers file, and the way we run `makepkg` via bash (since we need to change directory inside the chroot).

Can be installed via:
- aur_packages field in presets
- aur-packages argument for the create command

User can specify the AUR helper to use with `--aur-helper`

At the moment only `yay` is implemented

More can be implemented by providing their (non-interactive) install
command and name as an instance of the AurHelper struct.

Note makepkg and yay will not run under root user, so we must create a
temporary non-root user and clean up afterwards.