### PR TITLE
Support paru as AurHelper

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -84,7 +84,7 @@ pub struct CreateCommand {
     #[structopt(long = "allow-non-removable")]
     pub allow_non_removable: bool,
 
-    #[structopt(long = "aur-helper", possible_values=&["yay"], default_value="yay")]
+    #[structopt(long = "aur-helper", possible_values=&["paru", "yay"], default_value="yay")]
     pub aur_helper: AurHelper,
 }
 

--- a/src/aur.rs
+++ b/src/aur.rs
@@ -12,6 +12,25 @@ impl FromStr for AurHelper {
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
         match s {
+            "paru" => Ok(Self {
+                name: String::from("paru"),
+                package_name: String::from("paru-bin"),
+                install_command: vec![
+                    String::from("paru"),
+                    String::from("-S"),
+                    String::from("--skipreview"),
+                    String::from("--noupgrademenu"),
+                    String::from("--useask"),
+                    String::from("--removemake"),
+                    String::from("--norebuild"),
+                    String::from("--nocleanafter"),
+                    String::from("--noredownload"),
+                    String::from("--mflags"),
+                    String::from(""),
+                    String::from("--noconfirm"),
+                    String::from("--batchinstall"),
+                ],
+            }),
             "yay" => Ok(Self {
                 name: String::from("yay"),
                 package_name: String::from("yay-bin"),
@@ -25,7 +44,6 @@ impl FromStr for AurHelper {
                     String::from("--useask"),
                     String::from("--removemake"),
                     String::from("--norebuild"),
-                    String::from("--noconfirm"),
                     String::from("--answeredit"),
                     String::from("None"),
                     String::from("--answerclean"),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -19,5 +19,4 @@ pub const BASE_PACKAGES: [&str; 9] = [
     "amd-ucode",
 ];
 
-// we add go so that it is cached when installing yay
 pub const AUR_DEPENDENCIES: [&str; 3] = ["base-devel", "git", "sudo"];


### PR DESCRIPTION
Add support for [paru](https://github.com/Morganamilo/paru) as AurHelper.

As its also a rust tool it could be discussed if it should be preferred over yay as a default.

The install_command is mainly an adaptation from the one of yay. It is adapted to the commands of paru.
I added `--batchinstall` as I think its helpful to switch less often between building/installing.